### PR TITLE
Fix pushing from non-default branch

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -36,4 +36,5 @@ target_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${TARGET_R
 
 git clone "${upstream_repo}"
 cd "${upstream_dir}"
+git checkout "${INPUT_TARGET_BRANCH}"
 git push $_FORCE_OPTION --follow-tags $_TAGS "${target_repo}" "${INPUT_UPSTREAM_BRANCH}:${INPUT_TARGET_BRANCH}"


### PR DESCRIPTION
Fix bug #10

Problem was that git wanted to push branch which was only as remote branch at the time of push. 
I recreated it locally and simple checkout before push should fix it.