### PR TITLE
Build remote branch names matrix without clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ jobs:
 
           JSON="$(git ls-remote --heads "$upstream_repo" | jq -McnR "$jq_script")"
 
+          # debug matrix pretty json formatted output
+          jq --monochrome-output . -- <<< "$JSON"
+
           echo "::set-output name=matrix::$( echo "$JSON" )"
 
         env:

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ jobs:
         id: set-matrix
         run: |
           upstream_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${INPUT_UPSTREAM_REPOSITORY}.git"
-          
+
           # these jq scripts will produce the same matrix jobs by default
           # choose the one that works for any additional values that you may need to build your matrix with
-          # jq_script='{ "branch": [inputs | split("\n") | .[] | gsub(".*refs/heads/"; "")] }'   # {"branch":["$branch_name_1","$branch_name_2"]}
-          jq_script='[inputs | split("\n") | .[] | gsub(".*refs/heads/"; "") | { "branch": . }]' # [{"branch":"$branch_name_1"},{"branch":"$branch_name_2"}]
-          
+          jq_script='{ "branch": [inputs | split("\n") | .[] | gsub(".*refs/heads/"; "")] }'   # {"branch":["$branch_name_1","$branch_name_2"]}
+          # jq_script='[inputs | split("\n") | .[] | gsub(".*refs/heads/"; "") | { "branch": . }]' # [{"branch":"$branch_name_1"},{"branch":"$branch_name_2"}]
+
           JSON="$(git ls-remote --heads "$upstream_repo" | jq -McnR "$jq_script")"
 
           echo "::set-output name=matrix::$( echo "$JSON" )"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ jobs:
           # debug matrix pretty json formatted output
           jq --monochrome-output . -- <<< "$JSON"
 
-          echo "::set-output name=matrix::$( echo "$JSON" )"
+          # set output variable named 'matrix' for use in subsequent jobs that 'needs' this job.
+          # https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
+          echo "::set-output name=matrix::$JSON"
 
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
`git ls-remote --heads $repository` will return the heads for the repository without requiring a clone
This will end up returning tab separated list of `sha\trefs/heads/$BRANCH_NAME`
jq can slurp the input, split on newline, and remove the `sha\trefs/heads/` string using sub/gsub, outputting
the array that may be used in the github job matrix.
The github job matrix can take a single object with a key and value of an array or it can take the array of hashes. Both produce the same single matrix

`{ "branch": ["a", "b"] }` produces the same matrix as `[{ "branch": "a" },{ "branch": "b" }]` where each matrix job will have access to `matrix.branch`


---

```shell
upstream_repo="https://github.com/cli/cli.git"
jq_script='[inputs | split("\n") | .[] | gsub(".*refs/heads/"; "") | { "branch": . }]'
git ls-remote --heads "$upstream_repo" | jq -McnR "$jq_script"
[{"branch":"accessible-survey"},{"branch":"actions-demo"},{"branch":"bad-branch"},{"branch":"bulk-cmd"},{"branch":"cmd-reference-1734"},{"branch":"codespace-bdmac-cli-cli-v675vwcx4w5"},{"branch":"config-spike"},{"branch":"darcyclarke-patch-1"},{"branch":"delete-me"},{"branch":"demo-branch"},{"branch":"empty-default-protocol"},{"branch":"env-tests"},{"branch":"fix-codespace-pending-create-panic"},{"branch":"frecency"},{"branch":"git-client"},{"branch":"git-push-mocks"},{"branch":"git-push-mocks-moq"},{"branch":"graphql-validate"},{"branch":"hack20-10"},{"branch":"hackday2102"},{"branch":"hackday2108"},{"branch":"integration-suite"},{"branch":"issue-edit-sets"},{"branch":"issue-frecency"},{"branch":"jg/event-handling-deux"},{"branch":"markdown-indent-override"},{"branch":"marwan/localcs"},{"branch":"mislav/markdown-renderer"},{"branch":"multi-graphql"},{"branch":"notifications"},{"branch":"patch-review-prototype"},{"branch":"pr-workflow"},{"branch":"query-builder"},{"branch":"release-1.3"},{"branch":"run-log-zip"},{"branch":"sign-windows-executables"},{"branch":"squash-edit-commit-msg"},{"branch":"stacks-prototype"},{"branch":"survey-cursor"},{"branch":"terminal-hyperlinks"},{"branch":"tmp-winget-bump"},{"branch":"trunk"},{"branch":"vim-diff"},{"branch":"workflow-dispatch"},{"branch":"workflow-test-spike"},{"branch":"workflow-view"},{"branch":"workflows"},{"branch":"yaml-cve"}]
```

```shell
upstream_repo="https://github.com/cli/cli.git"
jq_script='{ "branch": [inputs | split("\n") | .[] | gsub(".*refs/heads/"; "")] }'
git ls-remote --heads "$upstream_repo" | jq -McnR "$jq_script"
{"branch":["accessible-survey","actions-demo","bad-branch","bulk-cmd","cmd-reference-1734","codespace-bdmac-cli-cli-v675vwcx4w5","config-spike","darcyclarke-patch-1","delete-me","demo-branch","empty-default-protocol","env-tests","fix-codespace-pending-create-panic","frecency","git-client","git-push-mocks","git-push-mocks-moq","graphql-validate","hack20-10","hackday2102","hackday2108","integration-suite","issue-edit-sets","issue-frecency","jg/event-handling-deux","markdown-indent-override","marwan/localcs","mislav/markdown-renderer","multi-graphql","notifications","patch-review-prototype","pr-workflow","query-builder","release-1.3","run-log-zip","sign-windows-executables","squash-edit-commit-msg","stacks-prototype","survey-cursor","terminal-hyperlinks","tmp-winget-bump","trunk","vim-diff","workflow-dispatch","workflow-test-spike","workflow-view","workflows","yaml-cve"]}
```

```shell
upstream_repo="git@github.com:cli/cli.git"
jq_script='{ "branch": [inputs | split("\n") | .[] | gsub(".*refs/heads/"; "")] }'
git ls-remote --heads "$upstream_repo" | jq -McnR "$jq_script"
{"branch":["accessible-survey","actions-demo","bad-branch","bulk-cmd","cmd-reference-1734","codespace-bdmac-cli-cli-v675vwcx4w5","config-spike","darcyclarke-patch-1","delete-me","demo-branch","empty-default-protocol","env-tests","fix-codespace-pending-create-panic","frecency","git-client","git-push-mocks","git-push-mocks-moq","graphql-validate","hack20-10","hackday2102","hackday2108","integration-suite","issue-edit-sets","issue-frecency","jg/event-handling-deux","markdown-indent-override","marwan/localcs","mislav/markdown-renderer","multi-graphql","notifications","patch-review-prototype","pr-workflow","query-builder","release-1.3","run-log-zip","sign-windows-executables","squash-edit-commit-msg","stacks-prototype","survey-cursor","terminal-hyperlinks","tmp-winget-bump","trunk","vim-diff","workflow-dispatch","workflow-test-spike","workflow-view","workflows","yaml-cve"]}
```