### PR TITLE
Update node to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ inputs:
     description: 'Determines if --tags is used'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'start.js'


### PR DESCRIPTION
node12 is deprecated

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/